### PR TITLE
Some suggestions

### DIFF
--- a/src/acme/main.cljd
+++ b/src/acme/main.cljd
@@ -2,9 +2,11 @@
   (:require
    [pages.albums-list :as albums-list]
    ["package:flutter/material.dart" :as m]
-   [cljd.flutter :as f]))
+   [cljd.flutter :as f]
+   [models.albums-model :as albums-model]))
 
 (defn main []
+  (albums-model/register!)
   (f/run
    (m/MaterialApp
     .title "Fetch Data List Example"

--- a/src/models/albums_model.cljd
+++ b/src/models/albums_model.cljd
@@ -24,6 +24,4 @@
   (rd/reg-sub
    ::get-albums
    (fn [db _]
-     (:albums db nil)))
-
-  (rd/dispatch [::refresh-albums]))
+     (:albums db nil))))

--- a/src/pages/albums_list.cljd
+++ b/src/pages/albums_list.cljd
@@ -37,7 +37,7 @@
         #(rd/dispatch [::albums-model/refresh-albums]))))) ; Here dispatch to refresh the list
 
 (defn view []
-  (albums-model/register!)
+  (rd/dispatch [::albums-model/refresh-albums])
   (f/widget
    :watch [albums (rd/subscribe [::albums-model/get-albums])] ; Here subscribe to `get-albums`
    (if-some [{} albums]


### PR DESCRIPTION
Hello Etienne

In general the article looks very good, well done, and thank you for writing this!

Some suggestions on the article and minor code edits in this PR:

**Local vs Global state**

As the title suggests state management in general, it might be good to differentiate between global state vs local state

- global state, state that need to be shared between widgets
- local state, state that remains local to a single widget

Where re-dash is an option to deal with global state, and that local state might still be better served by an atom defined local to the widget (as mentioned here https://github.com/htihospitality/re-dash#5th-domino---view)


**rd/reg-event-fx & rd/reg-event-db**
Maybe mention this is the act of registering an event handler that can be dispatched to from anywhere in the code

**rd/reg-fx**
Maybe mention this is the act of registering an effect handler for doing the side effect of an http call

**rd/reg-sub**
Maybe mention this is the act registering a subscription function that can be subscribed to by any widget to query the derived state value (when it actually changes)

**(rd/dispatch [::refresh-albums])**
I would suggest this is moved outside the `register!` function to clearly separate the two concerns

- registering the handlers, which is a once off setup operation
- dispatching of events, that can happen from anywhere like user actions

**(albums-model/register!)**
I would suggest calling this outside `(f/run)` to ensure it is only called once and not accidentally multiple times when for example the view re-renders due to state changes via `:watch` as and when the codebase grows - even though this would still be safe, it will not be very efficient.

Then we call `(rd/dispatch [::albums-model/refresh-albums])` from the `view` constructor for the initial data load

Lastly, regarding the `CircularProgressIndicator`, your implementation is perfectly fine, just know the fetch example in the re-dash repo alternatively shows a way one can show/hide the `CircularProgressIndicator` depending on whether an http request is actually in flight (in progress)

Well done